### PR TITLE
package.json version was not being update

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,6 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md"],
         "message": "${nextRelease.version} CHANGELOG [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrbo/service-client-statsd",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Service Client plugin for reporting operational metrics to a StatsD daemon",
   "keywords": [
     "http",


### PR DESCRIPTION
This removes the assets array from the semantic-release config so it uses the default.