### PR TITLE
chore: ignore eslint-plugin-n major change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       - "@ExpediaGroup/catalyst-committers"
     open-pull-requests-limit: 10
     ignore:
+      # Ignore Node plugin for ESLint
+      - dependency-name: "eslint-plugin-n"
+        update-types: ["version-update:semver-major"]
       # Ignore Hapi major updates
       - dependency-name: "@hapi/hapi"
         update-types: ["version-update:semver-major"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# @vrbo/service-client-statsd
-[![NPM Version](https://img.shields.io/npm/v/@vrbo/service-client-statsd.svg?style=flat-square)](https://www.npmjs.com/package/@vrbo/service-client-statsd)
-![](https://github.com/ExpediaGroup/service-client-statsd/workflows/Node_CI/badge.svg)
-[![Dependency Status](https://david-dm.org/expediagroup/service-client-statsd.svg?theme=shields.io)](https://david-dm.org/expediagroup/service-client-statsd)
+![Node.js Version](https://img.shields.io/badge/node->=14.0.0-brightgreen.svg?longCache=true&style=flat&logo=node.js)
+![NPM Version](https://img.shields.io/badge/npm->=6.0.0-brightgreen.svg?longCache=true&style=flat&logo=npm)
 [![NPM Downloads](https://img.shields.io/npm/dm/@vrbo/service-client-statsd.svg?style=flat-square)](https://npm-stat.com/charts.html?package=@vrbo/service-client-statsd)
+
+# @vrbo/service-client-statsd
 
 A [Service Client](https://github.com/expediagroup/service-client) plugin for reporting operational metrics to a [StatsD](https://github.com/statsd/statsd) daemon.
 


### PR DESCRIPTION
## Description

### Chore
Prevent Dependabot major changes for `eslint-plugin-n`, since it drops support for Node.js v14 at [v16.0.0](https://github.com/eslint-community/eslint-plugin-n/releases/tag/16.0.0) release.

### Documentation
Updated standard badges in `README.md` to provide valid information about engine requirements.